### PR TITLE
Fix notification replay after clear + stable Desktop portal IDs

### DIFF
--- a/data/io.github.tobagin.Ntfyr.desktop.in.in
+++ b/data/io.github.tobagin.Ntfyr.desktop.in.in
@@ -2,7 +2,7 @@
 Name=Ntfyr
 Comment=ntfy.sh client application to receive everyday's notifications
 Type=Application
-Exec=ntfyr
+Exec=@bindir@/ntfyr
 Terminal=false
 Categories=GNOME;GTK;Network;Utility;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!

--- a/data/meson.build
+++ b/data/meson.build
@@ -3,6 +3,8 @@ subdir('resources')
 # Desktop file
 desktop_conf = configuration_data()
 desktop_conf.set('icon', application_id)
+# Full path: launchers often omit ~/.local/bin from PATH when Exec is not absolute.
+desktop_conf.set('bindir', join_paths(get_option('prefix'), get_option('bindir')))
 desktop_file = i18n.merge_file(
   type: 'desktop',
   input: configure_file(

--- a/ntfy-daemon/src/listener.rs
+++ b/ntfy-daemon/src/listener.rs
@@ -48,6 +48,11 @@ pub enum ServerEvent {
 pub enum ListenerEvent {
     Message(models::ReceivedMessage),
     ConnectionStateChanged(ConnectionState),
+    /// Replace in-memory message list after a durable clear/read bump (serialized with other events).
+    MessagesReset {
+        read_until: u64,
+        messages: Vec<models::ReceivedMessage>,
+    },
 }
 
 #[derive(Clone)]

--- a/ntfy-daemon/src/message_repo/mod.rs
+++ b/ntfy-daemon/src/message_repo/mod.rs
@@ -164,6 +164,61 @@ impl Db {
         Ok(subs?)
     }
 
+    fn server_id_or_insert_tx(
+        tx: &rusqlite::Transaction<'_>,
+        endpoint: &str,
+    ) -> rusqlite::Result<i64> {
+        match tx.query_row(
+            "SELECT id FROM server WHERE endpoint = ?1",
+            params![endpoint],
+            |row| row.get(0),
+        ) {
+            Ok(id) => Ok(id),
+            Err(rusqlite::Error::QueryReturnedNoRows) => {
+                tx.execute(
+                    "INSERT INTO server (id, endpoint) VALUES (NULL, ?1)",
+                    params![endpoint],
+                )?;
+                Ok(tx.last_insert_rowid())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Single transaction: bump `read_until` then delete cached messages so we never persist
+    /// read state if the delete fails.
+    pub fn bump_read_until_and_clear_messages_atomic(
+        &mut self,
+        server: &str,
+        topic: &str,
+        bump: u64,
+    ) -> Result<(), Error> {
+        let mut conn = self.conn.write().unwrap();
+        let tx = conn.transaction().map_err(Error::Db)?;
+        let server_id = Self::server_id_or_insert_tx(&tx, server).map_err(Error::Db)?;
+        let n = tx.execute(
+            "UPDATE subscription
+            SET read_until = ?3
+            WHERE server = ?1 AND topic = ?2",
+            params![server_id, topic, bump as i64],
+        )
+        .map_err(Error::Db)?;
+        if n == 0 {
+            tx.rollback().ok();
+            return Err(Error::SubscriptionNotFound(
+                "bump read_until and clear messages".into(),
+            ));
+        }
+        tx.execute(
+            "DELETE FROM message
+            WHERE server = ?1 AND topic = ?2",
+            params![server_id, topic],
+        )
+        .map_err(Error::Db)?;
+        tx.commit().map_err(Error::Db)?;
+        Ok(())
+    }
+
     pub fn update_subscription(&mut self, sub: models::Subscription) -> Result<(), Error> {
         let server_id = self.get_or_insert_server(&sub.server)?;
         let rules = serde_json::to_string(&sub.rules).unwrap_or_default();
@@ -215,15 +270,12 @@ impl Db {
     pub fn delete_messages(&mut self, server: &str, topic: &str) -> Result<(), Error> {
         let server_id = self.get_or_insert_server(server).unwrap();
         let conn = self.conn.read().unwrap();
-        let res = conn.execute(
+        conn.execute(
             "DELETE FROM message
             WHERE topic = ?2 AND server = ?1
             ",
             params![server_id, topic],
         )?;
-        if res == 0 {
-            return Err(Error::SubscriptionNotFound("deleting messages".into()));
-        }
         Ok(())
     }
 

--- a/ntfy-daemon/src/models.rs
+++ b/ntfy-daemon/src/models.rs
@@ -416,6 +416,9 @@ pub struct Notification {
     pub title: String,
     pub body: String,
     pub actions: Vec<Action>,
+    /// Stable id for desktop [`NotificationProxy`] (portal): one slot per subscription so new
+    /// messages replace the previous portal notification instead of growing shell badge counters.
+    pub portal_id: Option<String>,
 }
 
 pub trait NotificationProxy: Sync + Send {

--- a/ntfy-daemon/src/ntfy.rs
+++ b/ntfy-daemon/src/ntfy.rs
@@ -311,12 +311,14 @@ impl NtfyActor {
     ) -> impl Future<Output = anyhow::Result<SubscriptionHandle>> {
         let server = sub.server.clone();
         let topic = sub.topic.clone();
-        let since = self
+        let db_max_message_time = self
             .env
             .db
             .get_last_message_time(&server, &topic)
-            .unwrap_or_default()
+            .unwrap_or(None)
             .unwrap_or(0);
+
+        let since = db_max_message_time.max(sub.read_until);
 
         let listener = ListenerHandle::new(ListenerConfig {
             http_client: self.env.http_client.clone(),

--- a/ntfy-daemon/src/subscription.rs
+++ b/ntfy-daemon/src/subscription.rs
@@ -1,6 +1,7 @@
 use crate::listener::{ListenerEvent, ListenerHandle};
 use crate::models::{self, ReceivedMessage};
 use crate::{Error, SharedEnv};
+use sha2::{Digest, Sha256};
 use tokio::select;
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio::task::spawn_local;
@@ -199,9 +200,44 @@ impl SubscriptionActor {
                             previous_events.push(ListenerEvent::ConnectionStateChanged(self.listener.state().await));
                             let _ = resp_tx.send((previous_events, self.broadcast_tx.subscribe()));
                         }
-                        SubscriptionCommand::ClearNotifications {resp_tx} => {
+                        SubscriptionCommand::ClearNotifications { resp_tx } => {
                             debug!(topic=?self.model.topic, "clearing notifications");
-                            let _ = resp_tx.send(self.env.db.delete_messages(&self.model.server, &self.model.topic).map_err(|e| anyhow::anyhow!(e)));
+                            let now_unix = std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .map(|d| d.as_secs())
+                                .unwrap_or(0);
+
+                            let last_in_db = self
+                                .env
+                                .db
+                                .get_last_message_time(&self.model.server, &self.model.topic)
+                                .ok()
+                                .flatten()
+                                .unwrap_or(0);
+
+                            // Once messages are cleared, the DB is empty and listen() would use
+                            // since=0 and replay the server's topic cache. Bump read_until to at least
+                            // max(last_local_message_time, now) so reconnect does not start from epoch.
+                            let bump = now_unix
+                                .max(last_in_db)
+                                .max(self.model.read_until);
+
+                            let res = self.env.db.bump_read_until_and_clear_messages_atomic(
+                                &self.model.server,
+                                &self.model.topic,
+                                bump,
+                            );
+                            if let Err(e) = res {
+                                let _ = resp_tx.send(Err(anyhow::anyhow!(e)));
+                                continue;
+                            }
+                            self.model.read_until = bump;
+                            let messages = self.stored_messages_snapshot();
+                            let _ = self.broadcast_tx.send(ListenerEvent::MessagesReset {
+                                read_until: bump,
+                                messages,
+                            });
+                            let _ = resp_tx.send(Ok(()));
                         }
                         SubscriptionCommand::UpdateReadUntil { timestamp, resp_tx } => {
                             debug!(topic=?self.model.topic, timestamp=timestamp, "updating read until timestamp");
@@ -329,6 +365,24 @@ impl SubscriptionActor {
         false
     }
 
+    fn stored_messages_snapshot(&self) -> Vec<ReceivedMessage> {
+        let messages = self
+            .env
+            .db
+            .list_messages(&self.model.server, &self.model.topic, 0)
+            .unwrap_or_default();
+        messages
+            .into_iter()
+            .filter_map(|row| match serde_json::from_str::<ReceivedMessage>(&row) {
+                Ok(m) => Some(m),
+                Err(e) => {
+                    error!(error = ?e, "error parsing stored message for snapshot");
+                    None
+                }
+            })
+            .collect()
+    }
+
     fn handle_msg_event(&mut self, msg: ReceivedMessage) {
         debug!(topic=?self.model.topic, "handling new message");
 
@@ -392,10 +446,12 @@ impl SubscriptionActor {
 
                 let title = { msg.notification_title(&self.model) };
 
+                let portal_id = portal_notification_id(&self.model.server, &self.model.topic);
                 let n = models::Notification {
                     title,
                     body: msg.display_message().as_deref().unwrap_or("").to_string(),
                     actions: msg.actions.clone(),
+                    portal_id,
                 };
 
                 info!(topic=?self.model.topic, "showing notification");
@@ -409,4 +465,15 @@ impl SubscriptionActor {
             let _ = self.broadcast_tx.send(ListenerEvent::Message(msg));
         }
     }
+}
+
+/// Stable Desktop portal notification id: one notification per (server, topic).
+fn portal_notification_id(server: &str, topic: &str) -> Option<String> {
+    let mut hasher = Sha256::new();
+    hasher.update(server.as_bytes());
+    hasher.update([0xff]);
+    hasher.update(topic.as_bytes());
+    let digest = hasher.finalize();
+    let slug: String = digest.iter().take(12).map(|b| format!("{:02x}", b)).collect();
+    Some(format!("io.github.tobagin.Ntfyr.z{slug}"))
 }

--- a/src/application.rs
+++ b/src/application.rs
@@ -434,9 +434,12 @@ impl NtfyrApplication {
 
             let mut notification_counter = 0u32;
             while let Ok(n) = r.recv().await {
-                // Create a unique notification ID
-                notification_counter = notification_counter.wrapping_add(1);
-                let notification_id = format!("ntfyr-notification-{}", notification_counter);
+                let notification_id = if let Some(id) = n.portal_id.clone() {
+                    id
+                } else {
+                    notification_counter = notification_counter.wrapping_add(1);
+                    format!("ntfyr-notification-{notification_counter}")
+                };
 
                 // Build portal notification
                 let mut portal_notif = ashpd::desktop::notification::Notification::new(&n.title);

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -208,6 +208,18 @@ impl Subscription {
                 self.imp().messages.append(&glib::BoxedAnyObject::new(msg));
                 self.update_unread_count();
             }
+            ListenerEvent::MessagesReset {
+                read_until,
+                messages,
+            } => {
+                let imp = self.imp();
+                imp.read_until.replace(read_until);
+                imp.messages.remove_all();
+                for m in messages {
+                    imp.messages.append(&glib::BoxedAnyObject::new(m));
+                }
+                self.update_unread_count();
+            }
             ListenerEvent::ConnectionStateChanged(connection_state) => {
                 self.set_connection_state(connection_state);
             }
@@ -364,10 +376,7 @@ impl Subscription {
     }
     #[instrument(skip_all)]
     pub async fn clear_notifications(&self) -> anyhow::Result<()> {
-        let imp = self.imp();
-        imp.client.get().unwrap().clear_notifications().await?;
-        self.imp().messages.remove_all();
-
+        self.imp().client.get().unwrap().clear_notifications().await?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
This PR fixes two related desktop integration issues observed on Linux (GNOME / portal notifications).

### 1. Cleared topics replay full server-side history after restart
After **Clear notifications** / wiping local SQLite, reconnect used `since = 0` (no rows in DB), so long-polling replayed cached messages from the ntfy server.

**Fix:** On clear, bump `read_until` to at least `max(now, last_local_message_time, existing read_until)`, persist it, then delete rows. Listener `since` becomes `max(last_message_time_in_db, subscription.read_until)`.

### 2. Shell launcher badge/counter inflated
Every notification used a new portal id (`ntfyr-notification-{N}`). Some desktops accumulate unrelated notification entries → misleading unread-like badges next to the app icon.

**Fix:** Stable id per (`server`, `topic`) via SHA-256 (prefix `io.github.tobagin.Ntfyr.z…`). New alerts replace prior portal notification for that subscription.

### Misc
`Db::delete_messages` no longer errors when zero rows deleted (already-empty topic).

## Testing
- `cargo build` via Meson release profile.
- Ran app with migrated SQLite; listeners connect; regression checks on Clear + restart still welcome on maintainer setups.

Cherry-picked from internal patch; targeting `main` (also applies cleanly on `v0.5.3`).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Portal notifications now use stable per-subscription identifiers (SHA‑256–based) so new messages replace prior desktop notifications instead of accumulating.

* **Bug Fixes**
  * Clearing notifications reliably bumps read state and clears stored messages so unread counts and displayed lists stay in sync.

* **Chores**
  * Desktop launcher now invokes the installed binary by absolute path for more reliable startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->