### PR TITLE
Fix missing notification history on first subscription

### DIFF
--- a/ntfy-daemon/src/listener.rs
+++ b/ntfy-daemon/src/listener.rs
@@ -384,11 +384,22 @@ impl ListenerHandle {
 mod tests {
     use models::Subscription;
     use serde_json::json;
-    use task::LocalSet;
+    use tokio::task::LocalSet;
 
     use crate::http_client::NullableClient;
 
     use super::*;
+
+    async fn test_listener_config(http_client: HttpClient) -> ListenerConfig {
+        ListenerConfig {
+            http_client,
+            credentials: Credentials::new_nullable(vec![]).await.unwrap(),
+            keys: crate::keys::Keys::new_nullable(std::collections::HashMap::new()).unwrap(),
+            endpoint: "http://localhost".to_string(),
+            topic: "test".to_string(),
+            since: 0,
+        }
+    }
 
     #[tokio::test]
     async fn test_listener_reconnects_on_http_status_500() {
@@ -403,15 +414,7 @@ mod tests {
                         .build();
                     nullable
                 });
-                let credentials = Credentials::new_nullable(vec![]).await.unwrap();
-
-                let config = ListenerConfig {
-                    http_client,
-                    credentials,
-                    endpoint: "http://localhost".to_string(),
-                    topic: "test".to_string(),
-                    since: 0,
-                };
+                let config = test_listener_config(http_client).await;
 
                 let listener = ListenerHandle::new(config.clone());
                 let items: Vec<_> = listener.events.take(3).collect().await;
@@ -442,15 +445,7 @@ mod tests {
                         .build();
                     nullable
                 });
-                let credentials = Credentials::new_nullable(vec![]).await.unwrap();
-
-                let config = ListenerConfig {
-                    http_client,
-                    credentials,
-                    endpoint: "http://localhost".to_string(),
-                    topic: "test".to_string(),
-                    since: 0,
-                };
+                let config = test_listener_config(http_client).await;
 
                 let listener = ListenerHandle::new(config.clone());
                 let items: Vec<_> = listener.events.take(3).collect().await;
@@ -464,6 +459,45 @@ mod tests {
                         ListenerEvent::ConnectionStateChanged(ConnectionState::Connected { .. }),
                     ]
                 ));
+            });
+        local_set.await;
+    }
+
+    #[tokio::test]
+    async fn test_listener_replays_cached_messages_from_since_zero() {
+        let local_set = LocalSet::new();
+        local_set
+            .spawn_local(async {
+                let body = format!(
+                    "{}\n{}\n",
+                    json!({"id":"open","time":1_700_000_000,"event":"open","topic":"test"}),
+                    json!({"id":"old1","time":1_700_000_001,"event":"message","topic":"test","message":"old"})
+                );
+
+                let http_client = HttpClient::new_nullable({
+                    let url = Subscription::build_url("http://localhost", "test", 0).unwrap();
+                    NullableClient::builder()
+                        .text_response(url.clone(), 200, body)
+                        .build()
+                });
+                let config = test_listener_config(http_client).await;
+
+                let listener = ListenerHandle::new(config);
+                let items: Vec<_> = listener.events.take(3).collect().await;
+
+                assert!(matches!(
+                    &items[..],
+                    &[
+                        ListenerEvent::ConnectionStateChanged(ConnectionState::Unitialized),
+                        ListenerEvent::ConnectionStateChanged(ConnectionState::Connected),
+                        ListenerEvent::Message(_),
+                    ]
+                ));
+                if let ListenerEvent::Message(msg) = &items[2] {
+                    assert_eq!(msg.id, "old1");
+                } else {
+                    panic!("expected historical message");
+                }
             });
         local_set.await;
     }

--- a/ntfy-daemon/src/message_repo/migrations/02.sql
+++ b/ntfy-daemon/src/message_repo/migrations/02.sql
@@ -1,0 +1,3 @@
+ALTER TABLE subscription ADD COLUMN listen_since INTEGER NOT NULL DEFAULT 0;
+UPDATE subscription
+SET listen_since = read_until;

--- a/ntfy-daemon/src/message_repo/mod.rs
+++ b/ntfy-daemon/src/message_repo/mod.rs
@@ -37,6 +37,10 @@ impl Db {
             conn.execute_batch(include_str!("./migrations/01.sql"))?;
             conn.pragma_update(None, "user_version", 2)?;
         }
+        if version < 3 {
+            conn.execute_batch(include_str!("./migrations/02.sql"))?;
+            conn.pragma_update(None, "user_version", 3)?;
+        }
         Ok(())
     }
     fn get_or_insert_server(&mut self, server: &str) -> Result<i64> {
@@ -107,7 +111,7 @@ impl Db {
         let schedule = serde_json::to_string(&sub.schedule).unwrap_or_default();
 
         self.conn.read().unwrap().execute(
-            "INSERT INTO subscription (server, topic, display_name, reserved, muted, archived, read_until, rules, schedule) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            "INSERT INTO subscription (server, topic, display_name, reserved, muted, archived, symbolic_icon, read_until, listen_since, rules, schedule) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
             params![
                 server_id,
                 sub.topic,
@@ -115,7 +119,9 @@ impl Db {
                 sub.reserved,
                 sub.muted,
                 sub.archived,
+                sub.symbolic_icon,
                 sub.read_until as i64,
+                sub.listen_since as i64,
                 rules,
                 schedule
             ],
@@ -137,15 +143,15 @@ impl Db {
     pub fn list_subscriptions(&mut self) -> Result<Vec<models::Subscription>, Error> {
         let conn = self.conn.read().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT server.endpoint, sub.topic, sub.display_name, sub.reserved, sub.muted, sub.archived, sub.symbolic_icon, sub.read_until, sub.rules, sub.schedule
+            "SELECT server.endpoint, sub.topic, sub.display_name, sub.reserved, sub.muted, sub.archived, sub.symbolic_icon, sub.read_until, sub.listen_since, sub.rules, sub.schedule
             FROM subscription sub
             JOIN server ON server.id = sub.server
             ORDER BY server.endpoint, sub.display_name, sub.topic
             ",
         )?;
         let rows = stmt.query_map(params![], |row| {
-            let rules_str: Option<String> = row.get(8)?;
-            let schedule_str: Option<String> = row.get(9)?;
+            let rules_str: Option<String> = row.get(9)?;
+            let schedule_str: Option<String> = row.get(10)?;
             
             Ok(models::Subscription {
                 server: row.get(0)?,
@@ -156,6 +162,7 @@ impl Db {
                 archived: row.get(5)?,
                 symbolic_icon: row.get(6)?,
                 read_until: row.get::<_, i64>(7)? as u64,
+                listen_since: row.get::<_, i64>(8)? as u64,
                 rules: rules_str.and_then(|s| serde_json::from_str(&s).ok()),
                 schedule: schedule_str.and_then(|s| serde_json::from_str(&s).ok()),
             })
@@ -198,7 +205,7 @@ impl Db {
         let server_id = Self::server_id_or_insert_tx(&tx, server).map_err(Error::Db)?;
         let n = tx.execute(
             "UPDATE subscription
-            SET read_until = ?3
+            SET read_until = ?3, listen_since = ?3
             WHERE server = ?1 AND topic = ?2",
             params![server_id, topic, bump as i64],
         )
@@ -226,18 +233,20 @@ impl Db {
 
         let res = self.conn.read().unwrap().execute(
             "UPDATE subscription
-            SET display_name = ?1, reserved = ?2, muted = ?3, archived = ?4, read_until = ?5, rules = ?8, schedule = ?9
-            WHERE server = ?6 AND topic = ?7",
+            SET display_name = ?1, reserved = ?2, muted = ?3, archived = ?4, symbolic_icon = ?5, read_until = ?6, listen_since = ?11, rules = ?9, schedule = ?10
+            WHERE server = ?7 AND topic = ?8",
             params![
                 sub.display_name,
                 sub.reserved,
                 sub.muted,
                 sub.archived,
+                sub.symbolic_icon,
                 sub.read_until as i64,
                 server_id,
                 sub.topic,
                 rules,
-                schedule
+                schedule,
+                sub.listen_since as i64,
             ],
         )?;
         if res == 0 {
@@ -298,5 +307,79 @@ impl Db {
         } else {
             Ok(None)
         }
+    }
+}
+
+pub(crate) fn compute_listen_since(db_max_message_time: u64, listen_since: u64) -> u64 {
+    db_max_message_time.max(listen_since)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models;
+
+    fn sample_message_json(topic: &str, id: &str, time: u64) -> String {
+        format!(
+            r#"{{"id":"{id}","time":{time},"event":"message","topic":"{topic}","message":"hello"}}"#
+        )
+    }
+
+    #[test]
+    fn compute_listen_since_prefers_local_cache() {
+        assert_eq!(compute_listen_since(100, 0), 100);
+        assert_eq!(compute_listen_since(100, 200), 200);
+    }
+
+    #[test]
+    fn new_subscription_with_read_until_still_fetches_history() {
+        let mut db = Db::connect(":memory:").unwrap();
+        let read_until = 1_700_000_000;
+        let sub = models::Subscription::builder("alerts".into())
+            .server("https://ntfy.example".into())
+            .read_until(read_until)
+            .build()
+            .unwrap();
+        db.insert_subscription(sub.clone()).unwrap();
+
+        let db_max = db
+            .get_last_message_time(&sub.server, &sub.topic)
+            .unwrap()
+            .unwrap_or(0);
+        let since = compute_listen_since(db_max, sub.listen_since);
+
+        assert_eq!(sub.read_until, read_until);
+        assert_eq!(sub.listen_since, 0);
+        assert_eq!(since, 0);
+    }
+
+    #[test]
+    fn cleared_subscription_skips_replayed_history() {
+        let mut db = Db::connect(":memory:").unwrap();
+        let sub = models::Subscription::builder("alerts".into())
+            .server("https://ntfy.example".into())
+            .build()
+            .unwrap();
+        db.insert_subscription(sub.clone()).unwrap();
+
+        let msg = sample_message_json("alerts", "abc", 1_700_000_010);
+        db.insert_message(&sub.server, &msg).unwrap();
+
+        db.bump_read_until_and_clear_messages_atomic(&sub.server, &sub.topic, 1_700_000_050)
+            .unwrap();
+
+        let stored = db.list_subscriptions().unwrap().pop().unwrap();
+        assert_eq!(stored.listen_since, 1_700_000_050);
+        assert!(db
+            .list_messages(&sub.server, &sub.topic, 0)
+            .unwrap()
+            .is_empty());
+
+        let db_max = db
+            .get_last_message_time(&sub.server, &sub.topic)
+            .unwrap()
+            .unwrap_or(0);
+        let since = compute_listen_since(db_max, stored.listen_since);
+        assert_eq!(since, 1_700_000_050);
     }
 }

--- a/ntfy-daemon/src/models.rs
+++ b/ntfy-daemon/src/models.rs
@@ -205,6 +205,11 @@ pub struct Subscription {
     pub reserved: bool,
     pub symbolic_icon: Option<String>,
     pub read_until: u64,
+    /// Earliest server message timestamp we still want to skip when reconnecting.
+    /// Separate from `read_until` so new subscriptions can fetch topic history while
+    /// marking pre-existing messages as read.
+    #[serde(default)]
+    pub listen_since: u64,
     #[serde(default)]
     pub rules: Option<Vec<FilterRule>>,
     #[serde(default)]
@@ -258,6 +263,7 @@ pub struct SubscriptionBuilder {
     symbolic_icon: Option<String>,
     display_name: String,
     read_until: u64,
+    listen_since: u64,
     rules: Option<Vec<FilterRule>>,
     schedule: Option<Schedule>,
 }
@@ -273,6 +279,7 @@ impl SubscriptionBuilder {
             symbolic_icon: None,
             display_name: String::new(),
             read_until: 0,
+            listen_since: 0,
             rules: None,
             schedule: None,
         }
@@ -313,6 +320,11 @@ impl SubscriptionBuilder {
         self
     }
 
+    pub fn listen_since(mut self, listen_since: u64) -> Self {
+        self.listen_since = listen_since;
+        self
+    }
+
     pub fn rules(mut self, rules: Option<Vec<FilterRule>>) -> Self {
         self.rules = rules;
         self
@@ -333,6 +345,7 @@ impl SubscriptionBuilder {
             symbolic_icon: self.symbolic_icon,
             display_name: self.display_name,
             read_until: self.read_until,
+            listen_since: self.listen_since,
             rules: self.rules,
             schedule: self.schedule,
         };

--- a/ntfy-daemon/src/ntfy.rs
+++ b/ntfy-daemon/src/ntfy.rs
@@ -318,7 +318,7 @@ impl NtfyActor {
             .unwrap_or(None)
             .unwrap_or(0);
 
-        let since = db_max_message_time.max(sub.read_until);
+        let since = crate::message_repo::compute_listen_since(db_max_message_time, sub.listen_since);
 
         let listener = ListenerHandle::new(ListenerConfig {
             http_client: self.env.http_client.clone(),
@@ -524,10 +524,9 @@ pub fn start(
 mod tests {
     use std::time::Duration;
 
-    use models::{OutgoingMessage, ReceivedMessage};
-    use tokio::time::sleep;
-
     use crate::ListenerEvent;
+    use models::{NullNetworkMonitor, NullNotifier, OutgoingMessage};
+    use tokio::time::sleep;
 
     use super::*;
 
@@ -552,23 +551,103 @@ mod tests {
             let subscription_handle = handle.subscribe(server, topic).await.unwrap();
 
             // Publish a message
-            let message = serde_json::to_string(&OutgoingMessage {
+            let message = OutgoingMessage {
                 topic: topic.to_string(),
                 ..Default::default()
-            })
-            .unwrap();
-            let result = subscription_handle.publish(message).await;
+            };
+            let result = subscription_handle.publish(message, false).await;
             assert!(result.is_ok());
 
             sleep(Duration::from_millis(250)).await;
 
             // Attach to the subscription and check if the message is received and stored
-            let (events, receiver) = subscription_handle.attach().await;
+            let (events, _receiver) = subscription_handle.attach().await;
             dbg!(&events);
             assert!(events.iter().any(|event| match event {
                 ListenerEvent::Message(msg) => msg.topic == topic,
                 _ => false,
             }));
         });
+    }
+
+    #[test]
+    #[ignore = "hits the live ntfy.sh server; run with: cargo test -p ntfy-daemon integration_subscribe_fetches_server_history -- --ignored"]
+    fn integration_subscribe_fetches_server_history() {
+        let topic = format!("ntfyr-hist-it-{}", std::process::id());
+        let dbpath = std::env::temp_dir().join(format!("ntfyr-it-{topic}.sqlite"));
+        let _ = std::fs::remove_file(&dbpath);
+
+        let handle = start(
+            dbpath.to_str().unwrap(),
+            Arc::new(NullNotifier::new()),
+            Arc::new(NullNetworkMonitor::new()),
+        )
+        .unwrap();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        rt.block_on(async {
+            let server = models::DEFAULT_SERVER;
+            let publish_url = format!("{server}/{topic}");
+
+            let client = reqwest::Client::new();
+            client
+                .post(&publish_url)
+                .body("historical one")
+                .header("Title", "History 1")
+                .send()
+                .await
+                .expect("first publish")
+                .error_for_status()
+                .expect("first publish status");
+            client
+                .post(&publish_url)
+                .body("historical two")
+                .header("Title", "History 2")
+                .send()
+                .await
+                .expect("second publish")
+                .error_for_status()
+                .expect("second publish status");
+
+            let subscription_handle = handle
+                .subscribe(server, &topic)
+                .await
+                .expect("subscribe");
+
+            sleep(Duration::from_secs(3)).await;
+
+            let (events, mut rx) = subscription_handle.attach().await;
+            let mut messages: Vec<_> = events
+                .into_iter()
+                .filter_map(|event| match event {
+                    ListenerEvent::Message(msg) => Some(msg),
+                    _ => None,
+                })
+                .collect();
+
+            let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+            while messages.len() < 2 && tokio::time::Instant::now() < deadline {
+                if let Ok(Ok(ListenerEvent::Message(msg))) =
+                    tokio::time::timeout(Duration::from_secs(1), rx.recv()).await
+                {
+                    messages.push(msg);
+                }
+            }
+
+            assert!(
+                messages.len() >= 2,
+                "expected cached server messages, got {messages:?}"
+            );
+
+            let model = subscription_handle.model().await;
+            assert_eq!(model.listen_since, 0);
+            assert!(model.read_until > 0);
+        });
+
+        let _ = std::fs::remove_file(dbpath);
     }
 }

--- a/ntfy-daemon/src/subscription.rs
+++ b/ntfy-daemon/src/subscription.rs
@@ -166,6 +166,7 @@ impl SubscriptionActor {
                             new_model.server = self.model.server.clone();
                             new_model.topic = self.model.topic.clone();
                             new_model.read_until = self.model.read_until;
+                            new_model.listen_since = self.model.listen_since;
                             let res = self.env.db.update_subscription(new_model.clone());
                             if let Ok(_) = res {
                                 self.model = new_model;
@@ -216,8 +217,9 @@ impl SubscriptionActor {
                                 .unwrap_or(0);
 
                             // Once messages are cleared, the DB is empty and listen() would use
-                            // since=0 and replay the server's topic cache. Bump read_until to at least
-                            // max(last_local_message_time, now) so reconnect does not start from epoch.
+                            // since=0 and replay the server's topic cache. Bump read_until and
+                            // listen_since to at least max(last_local_message_time, now) so
+                            // reconnect does not start from epoch.
                             let bump = now_unix
                                 .max(last_in_db)
                                 .max(self.model.read_until);
@@ -232,6 +234,7 @@ impl SubscriptionActor {
                                 continue;
                             }
                             self.model.read_until = bump;
+                            self.model.listen_since = bump;
                             let messages = self.stored_messages_snapshot();
                             let _ = self.broadcast_tx.send(ListenerEvent::MessagesReset {
                                 read_until: bump,


### PR DESCRIPTION
## Summary

- Introduces a separate `listen_since` field on subscriptions so the SSE `since` cursor is no longer tied to `read_until`.
- New subscriptions still set `read_until` to the current time (old messages appear as already read and do not trigger desktop notifications), but the listener now connects with `since=0` and loads the server topic cache.
- Clearing notifications bumps both `read_until` and `listen_since`, preserving the previous behavior of not replaying cleared history after reconnect.
- Adds unit and integration tests for the new fetch behavior.

## Root cause

On subscribe, `read_until` was set to the current Unix timestamp and also used to compute the SSE `since` parameter (`max(db_max, read_until)`). For a fresh install this skipped all messages already on the server before the app was installed.

## Test plan

- [ ] `cargo test -p ntfy-daemon` (integration test against ntfy.sh)
- [ ] Dev Flatpak build (`./build.sh --dev`) — uses `io.github.tobagin.Ntfyr.Devel`, separate from the production install
- [ ] Subscribe to a topic that already has messages on the server and confirm they appear in the message list
- [ ] Clear notifications and confirm old messages are not replayed after reconnect


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message history replay behavior to correctly handle reconnection scenarios and respect notification clearing boundaries.

* **Tests**
  * Added comprehensive test coverage for message history fetching and replay functionality.
  * New integration test ensures cached messages are properly replayed when resubscribing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->