### PR TITLE
docs: refresh README for v0.6.1 and add translations

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,140 @@
+# Ntfyr
+
+**Sprachen:** [English](README.md) · [Русский](README.ru.md) · [Deutsch](README.de.md) · [Español](README.es.md) · [Français](README.fr.md) · [Português](README.pt.md)
+
+Ein nativer [ntfy.sh](https://ntfy.sh/)-Client für den GNOME-Desktop. Entwickelt mit Rust, GTK4 und Libadwaita; als Flatpak verfügbar.
+
+<div align="center">
+
+![Ntfyr Application](data/screenshots/main-window.png)
+
+<a href="https://flathub.org/en/apps/io.github.tobagin.Ntfyr"><img src="https://flathub.org/api/badge" height="110" alt="Get it on Flathub"></a>
+<a href="https://ko-fi.com/tobagin"><img src="data/kofi_button.png" height="82" alt="Support me on Ko-Fi"></a>
+
+</div>
+
+## Aktuelles Release: 0.6.1
+
+Auszug der neuesten Änderungen (vollständige Historie in [CHANGELOG.md](CHANGELOG.md)):
+
+- **Sprachauswahl in der Oberfläche** — Sprache in den Einstellungen wählen (System, Englisch US/UK, Russisch, Deutsch, Spanisch, Französisch, Portugiesisch PT/BR); nach Neustart gelten Übersetzungen app-weit.
+- **Benachrichtigungsverlauf bei neuer Subscription** — neue Abonnements laden den Server-Topic-Cache, ohne gelöschte Nachrichten erneut zu liefern oder Desktop-Benachrichtigungen zu spamen.
+- **Zuverlässiger Hintergrundbetrieb** — erneutes Starten aus dem Launcher zeigt immer das Fenster; verbesserte Tray- und Portal-Integration unter GNOME und KDE.
+- **Self-Hosting** — HTTPS für private Server, stabile Desktop-Benachrichtigungs-IDs, atomisches Leeren und robuste Keyring-Fallbacks, wenn das Secret-Portal nicht verfügbar ist.
+- **0.6.1** — Wartungsrelease mit aktualisierten Rust-Abhängigkeiten (GTK 0.22 / ashpd 0.13 / reqwest 0.13).
+
+Installieren Sie die stabile Version über [Flathub](https://flathub.org/en/apps/io.github.tobagin.Ntfyr) oder bauen Sie aus den Quellen (unten).
+
+## Funktionen
+
+### Kern
+- **Native Desktop-Integration** — GTK4 + Libadwaita, GNOME Platform 50.
+- **Push-Benachrichtigungen** — Topics auf `ntfy.sh` oder selbst gehosteten Servern abonnieren.
+- **Hintergrund-Daemon** — In-Process-Backend hält SSE-Verbindungen und liefert Desktop-Benachrichtigungen.
+- **Lokaler Verlauf** — Nachrichten in SQLite für Offline-Ansicht und Suche.
+- **Mehrere Server** — Abonnements nach Server gruppiert; Standard-`ntfy.sh`-Eintrag ein- oder ausblendbar.
+
+### Benachrichtigungen & Inhalte
+- **Ende-zu-Ende-Verschlüsselung** — verschlüsselte Nachrichten senden und empfangen.
+- **Anhänge** — Bilder anzeigen und Dateien in der App herunterladen.
+- **Aktionsschaltflächen** — Links öffnen und HTTP-Aktionen aus Benachrichtigungen ausführen.
+- **Filter** — Filterregeln pro Abonnement.
+
+### Datenschutz & Sicherheit
+- **App-Sperre** — optional PIN/Biometrie beim Start (über System-Keyring).
+- **Self-Hosting** — private ntfy-Instanzen per HTTPS.
+- **Flatpak-Sandbox** — strenge Berechtigungen; keine Telemetrie.
+- **Nur lokale Daten** — Einstellungen und Verlauf bleiben auf Ihrem Rechner.
+
+### Desktop-UX
+- **System-Tray** — Schnellzugriff und Ungelesen-Anzeige (symbolisches Icon auf dunklen Panels).
+- **Tastenkürzel** — `Ctrl+N` neues Topic, `Ctrl+F` Suche, `Ctrl+,` Einstellungen, `F1` Hilfe.
+- **Einstellungen** — Datums-/Zeitformat, Autostart, Hintergrundstart, Fensterzustand.
+- **Dark Mode** — folgt dem Systemthema.
+
+### Übersetzungen
+
+Oberfläche verfügbar auf Englisch, Russisch, Deutsch, Spanisch, Französisch und Portugiesisch (europäische und brasilianische Varianten in der App). Weitere Sprachen über gettext — siehe [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Aus Quellen bauen
+
+Erfordert Flatpak, `flatpak-builder` und GNOME-50-SDK/Runtime (wird vom Build-Skript automatisch von Flathub installiert).
+
+```bash
+git clone https://github.com/tobagin/Ntfyr.git
+cd Ntfyr
+
+# Production (io.github.tobagin.Ntfyr)
+./build.sh
+
+# Development (io.github.tobagin.Ntfyr.Devel, Debug-Profil, Pre-Commit-Hook)
+./build.sh --dev
+```
+
+Jeder Build wird im Benutzer-Flatpak-Repo `~/repo` installiert. Start:
+
+```bash
+flatpak run io.github.tobagin.Ntfyr          # production
+flatpak run io.github.tobagin.Ntfyr.Devel    # development
+```
+
+Schnellere Iteration ohne Flatpak (Host-Pakete `gtk4-devel`, `libadwaita-devel` erforderlich):
+
+```bash
+cargo check   # Typprüfung
+cargo clippy  # Lint
+cargo run     # aus Quellen starten
+```
+
+Architektur: [CLAUDE.md](CLAUDE.md), Entwicklungsworkflow: [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Verwendung
+
+Ntfyr aus dem Anwendungsmenü starten oder:
+
+```bash
+flatpak run io.github.tobagin.Ntfyr
+```
+
+1. **+** klicken, um ein Abonnement hinzuzufügen.
+2. Topic-Namen eingeben (z. B. `alerts`).
+3. Optional einen eigenen Server wählen oder in den Einstellungen hinzufügen.
+
+Testbenachrichtigung senden:
+
+```bash
+curl -d "Hello from CLI" ntfy.sh/mytopic
+```
+
+### Tastenkürzel
+
+| Kürzel | Aktion |
+|--------|--------|
+| `Ctrl+N` | Neues Topic abonnieren |
+| `Ctrl+F` | Benachrichtigungen durchsuchen |
+| `Ctrl+,` | Einstellungen öffnen |
+| `Ctrl+Q` | Beenden |
+| `F1` | Tastenkürzel anzeigen |
+
+## Mitwirken
+
+Beiträge sind willkommen! Bitte [CONTRIBUTING.md](CONTRIBUTING.md) lesen, bevor Sie einen Pull Request öffnen.
+
+- **Fehler:** [GitHub Issues](https://github.com/tobagin/Ntfyr/issues)
+- **Fragen & Ideen:** [GitHub Discussions](https://github.com/tobagin/Ntfyr/discussions)
+
+## Lizenz
+
+Ntfyr steht unter [GPL-3.0-or-later](LICENSE).
+
+## Danksagungen
+
+- [ntfy.sh](https://ntfy.sh/) — die Benachrichtigungsplattform.
+- [GNOME](https://www.gnome.org/) — GTK4 und Libadwaita.
+- [Rust](https://www.rust-lang.org/) — Implementierung von App und Daemon.
+
+## Screenshots
+
+| Hauptfenster | Topics | Einstellungen |
+|--------------|--------|---------------|
+| ![Main window](data/screenshots/main-window.png) | ![Topics](data/screenshots/topics.png) | ![Preferences](data/screenshots/preferences.png) |

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,140 @@
+# Ntfyr
+
+**Idiomas:** [English](README.md) · [Русский](README.ru.md) · [Deutsch](README.de.md) · [Español](README.es.md) · [Français](README.fr.md) · [Português](README.pt.md)
+
+Cliente nativo de [ntfy.sh](https://ntfy.sh/) para el escritorio GNOME. Desarrollado con Rust, GTK4 y Libadwaita; distribuido como Flatpak.
+
+<div align="center">
+
+![Ntfyr Application](data/screenshots/main-window.png)
+
+<a href="https://flathub.org/en/apps/io.github.tobagin.Ntfyr"><img src="https://flathub.org/api/badge" height="110" alt="Get it on Flathub"></a>
+<a href="https://ko-fi.com/tobagin"><img src="data/kofi_button.png" height="82" alt="Support me on Ko-Fi"></a>
+
+</div>
+
+## Última versión: 0.6.1
+
+Resumen de cambios recientes (historial completo en [CHANGELOG.md](CHANGELOG.md)):
+
+- **Selector de idioma de la interfaz** — elige el idioma en Preferencias (sistema, inglés US/UK, ruso, alemán, español, francés, portugués PT/BR); al reiniciar se aplican las traducciones en toda la app.
+- **Historial al suscribirse** — las suscripciones nuevas cargan la caché del tema del servidor sin reenviar mensajes borrados ni saturar con alertas de escritorio.
+- **Modo en segundo plano fiable** — reactivar desde el lanzador siempre muestra la ventana; mejor integración con la bandeja y portales en GNOME y KDE.
+- **Self-hosted** — servidores privados HTTPS, IDs estables de notificaciones de escritorio, borrado atómico y respaldos robustos del keyring si el portal Secret no está disponible.
+- **0.6.1** — versión de mantenimiento con dependencias Rust actualizadas (GTK 0.22 / ashpd 0.13 / reqwest 0.13).
+
+Instala la versión estable desde [Flathub](https://flathub.org/en/apps/io.github.tobagin.Ntfyr) o compila desde el código fuente (abajo).
+
+## Características
+
+### Núcleo
+- **Integración nativa** — GTK4 + Libadwaita, GNOME Platform 50.
+- **Notificaciones push** — suscríbete a temas en `ntfy.sh` o servidores propios.
+- **Daemon en segundo plano** — backend en proceso mantiene conexiones SSE y entrega notificaciones de escritorio.
+- **Historial local** — mensajes en SQLite para consulta sin conexión y búsqueda.
+- **Varios servidores** — suscripciones agrupadas por servidor; ocultar o mostrar `ntfy.sh` por defecto.
+
+### Notificaciones y contenido
+- **Cifrado de extremo a extremo** — enviar y recibir mensajes cifrados.
+- **Adjuntos** — ver imágenes y descargar archivos en la app.
+- **Botones de acción** — abrir enlaces y ejecutar acciones HTTP desde notificaciones.
+- **Filtros** — reglas de filtrado por suscripción.
+
+### Privacidad y seguridad
+- **Bloqueo de la app** — PIN/biometría opcional al iniciar (mediante keyring del sistema).
+- **Self-hosted** — conectar a instancias ntfy privadas por HTTPS.
+- **Flatpak aislado** — permisos estrictos; sin telemetría.
+- **Solo datos locales** — ajustes e historial permanecen en tu equipo.
+
+### Experiencia de escritorio
+- **Bandeja del sistema** — acceso rápido e indicador de no leídos (icono simbólico en paneles oscuros).
+- **Atajos de teclado** — `Ctrl+N` nuevo tema, `Ctrl+F` buscar, `Ctrl+,` preferencias, `F1` ayuda.
+- **Preferencias** — formato de fecha/hora, inicio automático, arranque en segundo plano, estado de ventana.
+- **Modo oscuro** — sigue el tema del sistema.
+
+### Traducciones
+
+Interfaz disponible en inglés, ruso, alemán, español, francés y portugués (variantes europea y brasileña en la app). Más idiomas vía gettext — consulta [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Compilar desde el código fuente
+
+Requiere Flatpak, `flatpak-builder` y SDK/runtime GNOME 50 (el script de compilación los instala desde Flathub).
+
+```bash
+git clone https://github.com/tobagin/Ntfyr.git
+cd Ntfyr
+
+# Producción (io.github.tobagin.Ntfyr)
+./build.sh
+
+# Desarrollo (io.github.tobagin.Ntfyr.Devel, perfil debug, hook pre-commit)
+./build.sh --dev
+```
+
+Cada compilación se instala en el repositorio Flatpak de usuario `~/repo`. Ejecutar:
+
+```bash
+flatpak run io.github.tobagin.Ntfyr          # production
+flatpak run io.github.tobagin.Ntfyr.Devel    # development
+```
+
+Iteración rápida sin Flatpak (requiere paquetes `gtk4-devel`, `libadwaita-devel`):
+
+```bash
+cargo check   # comprobación de tipos
+cargo clippy  # lint
+cargo run     # ejecutar desde fuentes
+```
+
+Arquitectura: [CLAUDE.md](CLAUDE.md); flujo de desarrollo: [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Uso
+
+Inicia Ntfyr desde el menú de aplicaciones o ejecuta:
+
+```bash
+flatpak run io.github.tobagin.Ntfyr
+```
+
+1. Pulsa **+** para añadir una suscripción.
+2. Introduce el nombre del tema (p. ej. `alerts`).
+3. Opcionalmente elige un servidor personalizado o añádelo en Preferencias.
+
+Enviar una notificación de prueba:
+
+```bash
+curl -d "Hello from CLI" ntfy.sh/mytopic
+```
+
+### Atajos de teclado
+
+| Atajo | Acción |
+|-------|--------|
+| `Ctrl+N` | Suscribirse a un tema nuevo |
+| `Ctrl+F` | Buscar notificaciones |
+| `Ctrl+,` | Abrir Preferencias |
+| `Ctrl+Q` | Salir |
+| `F1` | Mostrar atajos de teclado |
+
+## Contribuir
+
+¡Las contribuciones son bienvenidas! Lee [CONTRIBUTING.md](CONTRIBUTING.md) antes de abrir un pull request.
+
+- **Errores:** [GitHub Issues](https://github.com/tobagin/Ntfyr/issues)
+- **Preguntas e ideas:** [GitHub Discussions](https://github.com/tobagin/Ntfyr/discussions)
+
+## Licencia
+
+Ntfyr está bajo [GPL-3.0-or-later](LICENSE).
+
+## Agradecimientos
+
+- [ntfy.sh](https://ntfy.sh/) — la plataforma de notificaciones.
+- [GNOME](https://www.gnome.org/) — GTK4 y Libadwaita.
+- [Rust](https://www.rust-lang.org/) — implementación de la app y el daemon.
+
+## Capturas de pantalla
+
+| Ventana principal | Temas | Preferencias |
+|-------------------|-------|--------------|
+| ![Main window](data/screenshots/main-window.png) | ![Topics](data/screenshots/topics.png) | ![Preferences](data/screenshots/preferences.png) |

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,140 @@
+# Ntfyr
+
+**Langues :** [English](README.md) · [Русский](README.ru.md) · [Deutsch](README.de.md) · [Español](README.es.md) · [Français](README.fr.md) · [Português](README.pt.md)
+
+Client natif [ntfy.sh](https://ntfy.sh/) pour le bureau GNOME. Développé en Rust avec GTK4 et Libadwaita ; distribué en Flatpak.
+
+<div align="center">
+
+![Ntfyr Application](data/screenshots/main-window.png)
+
+<a href="https://flathub.org/en/apps/io.github.tobagin.Ntfyr"><img src="https://flathub.org/api/badge" height="110" alt="Get it on Flathub"></a>
+<a href="https://ko-fi.com/tobagin"><img src="data/kofi_button.png" height="82" alt="Support me on Ko-Fi"></a>
+
+</div>
+
+## Dernière version : 0.6.1
+
+Points récents (historique complet dans [CHANGELOG.md](CHANGELOG.md)) :
+
+- **Sélecteur de langue de l’interface** — choisissez la langue dans les Préférences (système, anglais US/UK, russe, allemand, espagnol, français, portugais PT/BR) ; un redémarrage applique les traductions dans toute l’application.
+- **Historique à l’abonnement** — les nouveaux abonnements chargent le cache du topic serveur sans renvoyer les messages effacés ni saturer les alertes bureau.
+- **Mode arrière-plan fiable** — une réactivation depuis le lanceur affiche toujours la fenêtre ; intégration barre système et portails améliorée sous GNOME et KDE.
+- **Self-hosted** — serveurs privés HTTPS, identifiants stables des notifications bureau, effacement atomique et replis keyring robustes si le portail Secret est indisponible.
+- **0.6.1** — version de maintenance avec dépendances Rust mises à jour (GTK 0.22 / ashpd 0.13 / reqwest 0.13).
+
+Installez la version stable depuis [Flathub](https://flathub.org/en/apps/io.github.tobagin.Ntfyr) ou compilez depuis les sources (ci-dessous).
+
+## Fonctionnalités
+
+### Cœur
+- **Intégration bureau native** — GTK4 + Libadwaita, GNOME Platform 50.
+- **Notifications push** — abonnez-vous aux topics sur `ntfy.sh` ou serveurs auto-hébergés.
+- **Démon en arrière-plan** — backend in-process maintient les connexions SSE et livre les notifications bureau.
+- **Historique local** — messages en SQLite pour consultation hors ligne et recherche.
+- **Plusieurs serveurs** — abonnements groupés par serveur ; masquer ou afficher l’entrée `ntfy.sh` par défaut.
+
+### Notifications et contenu
+- **Chiffrement de bout en bout** — envoyer et recevoir des messages chiffrés.
+- **Pièces jointes** — afficher des images et télécharger des fichiers dans l’app.
+- **Boutons d’action** — ouvrir des liens et exécuter des actions HTTP depuis les notifications.
+- **Filtres** — règles de filtrage par abonnement.
+
+### Confidentialité et sécurité
+- **Verrouillage de l’app** — PIN/biométrie optionnel au démarrage (via keyring système).
+- **Self-hosted** — connexion à des instances ntfy privées en HTTPS.
+- **Flatpak sandboxé** — permissions strictes ; pas de télémétrie.
+- **Données locales uniquement** — réglages et historique restent sur votre machine.
+
+### Expérience bureau
+- **Barre système** — accès rapide et indicateur de non-lus (icône symbolique sur panneaux sombres).
+- **Raccourcis clavier** — `Ctrl+N` nouveau topic, `Ctrl+F` recherche, `Ctrl+,` préférences, `F1` aide.
+- **Préférences** — format date/heure, démarrage automatique, lancement en arrière-plan, état de la fenêtre.
+- **Mode sombre** — suit le thème système.
+
+### Traductions
+
+Interface disponible en anglais, russe, allemand, espagnol, français et portugais (variantes européenne et brésilienne dans l’app). D’autres langues via gettext — voir [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Compiler depuis les sources
+
+Nécessite Flatpak, `flatpak-builder` et le SDK/runtime GNOME 50 (installés automatiquement par le script depuis Flathub).
+
+```bash
+git clone https://github.com/tobagin/Ntfyr.git
+cd Ntfyr
+
+# Production (io.github.tobagin.Ntfyr)
+./build.sh
+
+# Développement (io.github.tobagin.Ntfyr.Devel, profil debug, hook pre-commit)
+./build.sh --dev
+```
+
+Chaque compilation s’installe dans le dépôt Flatpak utilisateur `~/repo`. Lancer :
+
+```bash
+flatpak run io.github.tobagin.Ntfyr          # production
+flatpak run io.github.tobagin.Ntfyr.Devel    # development
+```
+
+Itération rapide sans Flatpak (paquets hôte `gtk4-devel`, `libadwaita-devel` requis) :
+
+```bash
+cargo check   # vérification de types
+cargo clippy  # lint
+cargo run     # exécuter depuis les sources
+```
+
+Architecture : [CLAUDE.md](CLAUDE.md) ; workflow de développement : [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Utilisation
+
+Lancez Ntfyr depuis le menu applications ou exécutez :
+
+```bash
+flatpak run io.github.tobagin.Ntfyr
+```
+
+1. Cliquez sur **+** pour ajouter un abonnement.
+2. Saisissez le nom du topic (p. ex. `alerts`).
+3. Choisissez éventuellement un serveur personnalisé ou ajoutez-en un dans les Préférences.
+
+Envoyer une notification de test :
+
+```bash
+curl -d "Hello from CLI" ntfy.sh/mytopic
+```
+
+### Raccourcis clavier
+
+| Raccourci | Action |
+|-----------|--------|
+| `Ctrl+N` | S’abonner à un nouveau topic |
+| `Ctrl+F` | Rechercher dans les notifications |
+| `Ctrl+,` | Ouvrir les Préférences |
+| `Ctrl+Q` | Quitter |
+| `F1` | Afficher les raccourcis |
+
+## Contribuer
+
+Les contributions sont les bienvenues ! Lisez [CONTRIBUTING.md](CONTRIBUTING.md) avant d’ouvrir une pull request.
+
+- **Bugs :** [GitHub Issues](https://github.com/tobagin/Ntfyr/issues)
+- **Questions et idées :** [GitHub Discussions](https://github.com/tobagin/Ntfyr/discussions)
+
+## Licence
+
+Ntfyr est sous [GPL-3.0-or-later](LICENSE).
+
+## Remerciements
+
+- [ntfy.sh](https://ntfy.sh/) — la plateforme de notifications.
+- [GNOME](https://www.gnome.org/) — GTK4 et Libadwaita.
+- [Rust](https://www.rust-lang.org/) — implémentation de l’application et du démon.
+
+## Captures d’écran
+
+| Fenêtre principale | Topics | Préférences |
+|--------------------|--------|-------------|
+| ![Main window](data/screenshots/main-window.png) | ![Topics](data/screenshots/topics.png) | ![Preferences](data/screenshots/preferences.png) |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Ntfyr
 
-A native ntfy.sh client for the GNOME Desktop.
+**Languages:** [English](README.md) · [Русский](README.ru.md) · [Deutsch](README.de.md) · [Español](README.es.md) · [Français](README.fr.md) · [Português](README.pt.md)
+
+A native [ntfy.sh](https://ntfy.sh/) client for the GNOME desktop. Built with Rust, GTK4, and Libadwaita; distributed as a Flatpak.
 
 <div align="center">
 
@@ -11,118 +13,128 @@ A native ntfy.sh client for the GNOME Desktop.
 
 </div>
 
-## 🎉 Version 0.4.1 - Quick Fix
+## Latest release: 0.6.1
 
-**Ntfyr 0.4.1** is a quick fix release to address AppStream metadata issues.
+Recent highlights (see [CHANGELOG.md](CHANGELOG.md) for the full history):
 
-### ✨ Key Features
+- **UI language selector** — choose the interface language in Preferences (system, English US/UK, Russian, German, Spanish, French, Portuguese PT/BR); restart applies translations app-wide.
+- **Notification history on subscribe** — new subscriptions load the server topic cache without replaying cleared messages or spamming desktop alerts.
+- **Reliable background mode** — launcher reactivation always shows the window; tray and portal integration improved across GNOME and KDE.
+- **Self-hosted friendly** — HTTPS private servers, stable desktop notification IDs, atomic clear, and robust keyring fallbacks when the Secret portal is unavailable.
+- **0.6.1** — dependency maintenance release (updated Rust crates for GTK 0.22 / ashpd 0.13 / reqwest 0.13 stack).
 
-- **🚀 Native and Fast**: Built with Rust and GTK4 for a smooth, native experience.
-- **📨 Push Notifications**: Instant notifications from ntfy.sh or self-hosted servers.
-- **🔐 End-to-End Encryption**: Send and receive encrypted messages securely.
-- **🛡️ App Locking**: Protect your messages with a PIN code.
-- **🔄 Background Service**: Runs reliably in the background via system portals.
-- **📂 Attachments**: View images and download files directly within the app.
-- **🧩 Multiple Servers**: Group subscriptions by server for better organizational.
-- **🛡️ Privacy Focused**: Full support for self-hosted instances.
-
-### 🆕 What's New in 0.4.1
-
-- **Fixed**: AppStream metadata validation.
-- **Improved**: Release description formatting.
-
-For detailed release notes and version history, see [CHANGELOG.md](CHANGELOG.md).
+Install the latest stable build from [Flathub](https://flathub.org/en/apps/io.github.tobagin.Ntfyr) or build from source below.
 
 ## Features
 
-### Core Features
-- **Native Desktop Integration**: Uses GTK4 and Libadwaita for a perfect GNOME fit.
-- **Unified Server Management**: Manage subscriptions from `ntfy.sh` and custom servers in one list.
-- **Persistent Connection**: Daemonized backend ensures you never miss a notification.
+### Core
+- **Native desktop integration** — GTK4 + Libadwaita, GNOME Platform 50.
+- **Push notifications** — subscribe to topics on `ntfy.sh` or self-hosted servers.
+- **Background daemon** — in-process backend keeps SSE connections alive and delivers desktop notifications.
+- **Local history** — messages cached in SQLite for offline browsing and search.
+- **Multiple servers** — group subscriptions by server; hide or show the default `ntfy.sh` entry.
 
-### User Experience
-- **Action Buttons**: Interact with notifications (Open Link, HTTP actions).
-- **Shortcuts**: Keyboard shortcuts for quick navigation (`Ctrl+,`, `F1`, `Ctrl+N`).
-- **System Tray**: Quick access and unread status indication.
-- **Dark Mode**: Fully supports system-wide dark theme preference.
+### Notifications & content
+- **End-to-end encryption** — send and receive encrypted messages.
+- **Attachments** — view images and download files in-app.
+- **Action buttons** — open links and run HTTP actions from notifications.
+- **Filters** — per-subscription filter rules.
 
-### Privacy & Customization
-- **Self-Hosted Support**: Connect to your own ntfy server instances.
-- **Local History**: Notifications are cached locally for offline viewing.
-- **No Telemetry**: Your data stays on your machine.
+### Privacy & security
+- **App lock** — optional PIN/biometric lock on startup (via system keyring).
+- **Self-hosted support** — connect to private ntfy instances over HTTPS.
+- **Sandboxed Flatpak** — strict permissions; no telemetry.
+- **Local data only** — settings and history stay on your machine.
 
-## Building from Source
+### Desktop UX
+- **System tray** — quick access and unread indication (themed symbolic icon on dark panels).
+- **Keyboard shortcuts** — `Ctrl+N` new topic, `Ctrl+F` search, `Ctrl+,` preferences, `F1` help.
+- **Preferences** — customizable date/time format, autostart, background launch, window state.
+- **Dark mode** — follows the system theme.
+
+### Translations
+
+Interface available in English, Russian, German, Spanish, French, and Portuguese (European and Brazilian variants in the app). More languages can be added via gettext — see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Building from source
+
+Requires Flatpak, `flatpak-builder`, and the GNOME 50 SDK/runtime (installed automatically by the build script from Flathub).
 
 ```bash
-# Clone the repository
 git clone https://github.com/tobagin/Ntfyr.git
 cd Ntfyr
 
-# Build and install development version
+# Production build (io.github.tobagin.Ntfyr)
+./build.sh
+
+# Development build (io.github.tobagin.Ntfyr.Devel, debug profile, pre-commit hook)
 ./build.sh --dev
 ```
 
+Each build installs into the user Flatpak repo at `~/repo` and registers the app locally. Run:
+
+```bash
+flatpak run io.github.tobagin.Ntfyr          # production
+flatpak run io.github.tobagin.Ntfyr.Devel    # development
+```
+
+For faster iteration without Flatpak (host packages `gtk4-devel`, `libadwaita-devel` required):
+
+```bash
+cargo check   # type check
+cargo clippy  # lint
+cargo run     # run from source
+```
+
+See [CLAUDE.md](CLAUDE.md) for architecture notes and [CONTRIBUTING.md](CONTRIBUTING.md) for the full development workflow.
+
 ## Usage
 
-### Basic Usage
+Launch Ntfyr from the applications menu or run:
 
-Launch Ntfyr from your applications menu or run:
 ```bash
 flatpak run io.github.tobagin.Ntfyr
 ```
 
-1.  Click the **+** button to add a subscription.
-2.  Enter the topic component (e.g., `mytopic`).
-3.  (Optional) Select or add a custom server.
+1. Click **+** to add a subscription.
+2. Enter the topic name (e.g. `alerts`).
+3. Optionally pick a custom server or add one in Preferences.
 
-### Sending Notifications
-
-You can test Ntfyr using `curl`:
+Send a test notification:
 
 ```bash
 curl -d "Hello from CLI" ntfy.sh/mytopic
 ```
 
-### Keyboard Shortcuts
+### Keyboard shortcuts
 
-- `Ctrl+,` - Open Preferences
-- `Ctrl+Q` - Quit Application
-- `F1` - Show Shortcuts Help
-- `Ctrl+N` - Subscribe to new topic
-- `Ctrl+F` - Search notifications
-
-## Privacy & Security
-
-Ntfyr is designated to respect your privacy:
-
-- **Sandboxed**: Distributed as a Flatpak with strict permissions.
-- **Local Data**: All history and configuration is stored locally.
-- **Open Source**: Code is fully available for audit.
+| Shortcut | Action |
+|----------|--------|
+| `Ctrl+N` | Subscribe to new topic |
+| `Ctrl+F` | Search notifications |
+| `Ctrl+,` | Open Preferences |
+| `Ctrl+Q` | Quit |
+| `F1` | Show keyboard shortcuts |
 
 ## Contributing
 
-Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
 
-- Reporting Bugs: [GitHub Issues](https://github.com/tobagin/Ntfyr/issues)
-- Discussions: [GitHub Discussions](https://github.com/tobagin/Ntfyr/discussions)
+- **Bug reports:** [GitHub Issues](https://github.com/tobagin/Ntfyr/issues)
+- **Questions & ideas:** [GitHub Discussions](https://github.com/tobagin/Ntfyr/discussions)
 
 ## License
 
-Ntfyr is licensed under the [GPL-3.0-or-later](LICENSE).
+Ntfyr is licensed under [GPL-3.0-or-later](LICENSE).
 
 ## Acknowledgments
 
-- **ntfy.sh**: For the amazing notification platform.
-- **GNOME**: For the GTK toolkit.
-- **Rust**: For the language.
+- [ntfy.sh](https://ntfy.sh/) — the notification platform this client talks to.
+- [GNOME](https://www.gnome.org/) — GTK4 and Libadwaita.
+- [Rust](https://www.rust-lang.org/) — application and daemon implementation.
 
 ## Screenshots
 
-| Main Window | Topics View | Preferences |
-|-------------|-------------|-------------|
-| ![Main Window](data/screenshots/main-window.png) | ![Topics](data/screenshots/topics.png) | ![Preferences](data/screenshots/preferences.png) |
-
----
-
-**Ntfyr** - A native ntfy.sh client for the GNOME Desktop.
-
+| Main window | Topics | Preferences |
+|-------------|--------|-------------|
+| ![Main window](data/screenshots/main-window.png) | ![Topics](data/screenshots/topics.png) | ![Preferences](data/screenshots/preferences.png) |

--- a/README.pt.md
+++ b/README.pt.md
@@ -1,0 +1,140 @@
+# Ntfyr
+
+**Idiomas:** [English](README.md) · [Русский](README.ru.md) · [Deutsch](README.de.md) · [Español](README.es.md) · [Français](README.fr.md) · [Português](README.pt.md)
+
+Cliente nativo de [ntfy.sh](https://ntfy.sh/) para o ambiente de trabalho GNOME. Desenvolvido em Rust, GTK4 e Libadwaita; distribuído como Flatpak.
+
+<div align="center">
+
+![Ntfyr Application](data/screenshots/main-window.png)
+
+<a href="https://flathub.org/en/apps/io.github.tobagin.Ntfyr"><img src="https://flathub.org/api/badge" height="110" alt="Get it on Flathub"></a>
+<a href="https://ko-fi.com/tobagin"><img src="data/kofi_button.png" height="82" alt="Support me on Ko-Fi"></a>
+
+</div>
+
+## Última versão: 0.6.1
+
+Destaques recentes (histórico completo em [CHANGELOG.md](CHANGELOG.md)):
+
+- **Selector de idioma da interface** — escolha o idioma nas Preferências (sistema, inglês US/UK, russo, alemão, espanhol, francês, português PT/BR); após reiniciar, as traduções aplicam-se a toda a aplicação.
+- **Histórico ao subscrever** — novas subscrições carregam a cache do tópico no servidor sem reenviar mensagens apagadas nem inundar com alertas de secretária.
+- **Modo em segundo plano fiável** — reativar a partir do lançador mostra sempre a janela; integração com a bandeja e portais melhorada no GNOME e KDE.
+- **Self-hosted** — servidores privados HTTPS, IDs estáveis de notificações, limpeza atómica e fallbacks robustos do keyring quando o portal Secret não está disponível.
+- **0.6.1** — versão de manutenção com dependências Rust atualizadas (GTK 0.22 / ashpd 0.13 / reqwest 0.13).
+
+Instale a versão estável a partir do [Flathub](https://flathub.org/en/apps/io.github.tobagin.Ntfyr) ou compile a partir do código-fonte (abaixo).
+
+## Funcionalidades
+
+### Núcleo
+- **Integração nativa** — GTK4 + Libadwaita, GNOME Platform 50.
+- **Notificações push** — subscreva tópicos em `ntfy.sh` ou servidores auto-hospedados.
+- **Daemon em segundo plano** — backend in-process mantém ligações SSE e entrega notificações de secretária.
+- **Histórico local** — mensagens em SQLite para consulta offline e pesquisa.
+- **Vários servidores** — subscrições agrupadas por servidor; ocultar ou mostrar a entrada `ntfy.sh` predefinida.
+
+### Notificações e conteúdo
+- **Encriptação ponta a ponta** — enviar e receber mensagens encriptadas.
+- **Anexos** — ver imagens e transferir ficheiros na aplicação.
+- **Botões de ação** — abrir ligações e executar ações HTTP a partir de notificações.
+- **Filtros** — regras de filtragem por subscrição.
+
+### Privacidade e segurança
+- **Bloqueio da aplicação** — PIN/biometria opcional ao iniciar (via keyring do sistema).
+- **Self-hosted** — ligar a instâncias ntfy privadas por HTTPS.
+- **Flatpak isolado** — permissões restritas; sem telemetria.
+- **Apenas dados locais** — definições e histórico permanecem no seu computador.
+
+### Experiência de secretária
+- **Bandeja do sistema** — acesso rápido e indicador de não lidos (ícone simbólico em painéis escuros).
+- **Atalhos de teclado** — `Ctrl+N` novo tópico, `Ctrl+F` pesquisa, `Ctrl+,` preferências, `F1` ajuda.
+- **Preferências** — formato de data/hora, arranque automático, lançamento em segundo plano, estado da janela.
+- **Modo escuro** — segue o tema do sistema.
+
+### Traduções
+
+Interface disponível em inglês, russo, alemão, espanhol, francês e português (variantes europeia e brasileira na aplicação). Mais idiomas via gettext — consulte [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Compilar a partir do código-fonte
+
+Requer Flatpak, `flatpak-builder` e SDK/runtime GNOME 50 (instalados automaticamente pelo script a partir do Flathub).
+
+```bash
+git clone https://github.com/tobagin/Ntfyr.git
+cd Ntfyr
+
+# Produção (io.github.tobagin.Ntfyr)
+./build.sh
+
+# Desenvolvimento (io.github.tobagin.Ntfyr.Devel, perfil debug, hook pre-commit)
+./build.sh --dev
+```
+
+Cada compilação instala-se no repositório Flatpak do utilizador `~/repo`. Executar:
+
+```bash
+flatpak run io.github.tobagin.Ntfyr          # production
+flatpak run io.github.tobagin.Ntfyr.Devel    # development
+```
+
+Iteração rápida sem Flatpak (pacotes no sistema `gtk4-devel`, `libadwaita-devel` necessários):
+
+```bash
+cargo check   # verificação de tipos
+cargo clippy  # lint
+cargo run     # executar a partir do código-fonte
+```
+
+Arquitetura: [CLAUDE.md](CLAUDE.md); fluxo de desenvolvimento: [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Utilização
+
+Inicie o Ntfyr a partir do menu de aplicações ou execute:
+
+```bash
+flatpak run io.github.tobagin.Ntfyr
+```
+
+1. Clique em **+** para adicionar uma subscrição.
+2. Introduza o nome do tópico (p. ex. `alerts`).
+3. Opcionalmente escolha um servidor personalizado ou adicione um nas Preferências.
+
+Enviar uma notificação de teste:
+
+```bash
+curl -d "Hello from CLI" ntfy.sh/mytopic
+```
+
+### Atalhos de teclado
+
+| Atalho | Ação |
+|--------|------|
+| `Ctrl+N` | Subscrever novo tópico |
+| `Ctrl+F` | Pesquisar notificações |
+| `Ctrl+,` | Abrir Preferências |
+| `Ctrl+Q` | Sair |
+| `F1` | Mostrar atalhos de teclado |
+
+## Contribuir
+
+Contribuições são bem-vindas! Leia [CONTRIBUTING.md](CONTRIBUTING.md) antes de abrir um pull request.
+
+- **Erros:** [GitHub Issues](https://github.com/tobagin/Ntfyr/issues)
+- **Perguntas e ideias:** [GitHub Discussions](https://github.com/tobagin/Ntfyr/discussions)
+
+## Licença
+
+O Ntfyr está licenciado sob [GPL-3.0-or-later](LICENSE).
+
+## Agradecimentos
+
+- [ntfy.sh](https://ntfy.sh/) — a plataforma de notificações.
+- [GNOME](https://www.gnome.org/) — GTK4 e Libadwaita.
+- [Rust](https://www.rust-lang.org/) — implementação da aplicação e do daemon.
+
+## Capturas de ecrã
+
+| Janela principal | Tópicos | Preferências |
+|------------------|---------|--------------|
+| ![Main window](data/screenshots/main-window.png) | ![Topics](data/screenshots/topics.png) | ![Preferences](data/screenshots/preferences.png) |

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,0 +1,140 @@
+# Ntfyr
+
+**Языки:** [English](README.md) · [Русский](README.ru.md) · [Deutsch](README.de.md) · [Español](README.es.md) · [Français](README.fr.md) · [Português](README.pt.md)
+
+Нативный клиент [ntfy.sh](https://ntfy.sh/) для рабочего стола GNOME. Написан на Rust с GTK4 и Libadwaita; распространяется как Flatpak.
+
+<div align="center">
+
+![Ntfyr Application](data/screenshots/main-window.png)
+
+<a href="https://flathub.org/en/apps/io.github.tobagin.Ntfyr"><img src="https://flathub.org/api/badge" height="110" alt="Get it on Flathub"></a>
+<a href="https://ko-fi.com/tobagin"><img src="data/kofi_button.png" height="82" alt="Support me on Ko-Fi"></a>
+
+</div>
+
+## Последний релиз: 0.6.1
+
+Кратко о недавних изменениях (полная история — в [CHANGELOG.md](CHANGELOG.md)):
+
+- **Выбор языка интерфейса** — в настройках можно выбрать язык (системный, English US/UK, русский, немецкий, испанский, французский, португальский PT/BR); после перезапуска переводы применяются ко всему приложению.
+- **История при подписке** — новые подписки загружают кэш темы с сервера без повторной доставки очищенных сообщений и лишних desktop-уведомлений.
+- **Надёжный фоновый режим** — повторный запуск из меню всегда показывает окно; улучшена интеграция с треем и порталами в GNOME и KDE.
+- **Self-hosted** — HTTPS на частных серверах, стабильные ID desktop-уведомлений, атомарная очистка и устойчивые fallback'и keyring, если Secret portal недоступен.
+- **0.6.1** — технический релиз с обновлением Rust-зависимостей (GTK 0.22 / ashpd 0.13 / reqwest 0.13).
+
+Установите стабильную сборку с [Flathub](https://flathub.org/en/apps/io.github.tobagin.Ntfyr) или соберите из исходников (ниже).
+
+## Возможности
+
+### Основное
+- **Нативная интеграция** — GTK4 + Libadwaita, GNOME Platform 50.
+- **Push-уведомления** — подписки на темы `ntfy.sh` или собственных серверов.
+- **Фоновый демон** — встроенный backend держит SSE-соединения и доставляет desktop-уведомления.
+- **Локальная история** — сообщения в SQLite для просмотра офлайн и поиска.
+- **Несколько серверов** — группировка подписок по серверу; можно скрыть или показать `ntfy.sh` по умолчанию.
+
+### Уведомления и контент
+- **Сквозное шифрование** — отправка и приём зашифрованных сообщений.
+- **Вложения** — просмотр изображений и скачивание файлов в приложении.
+- **Кнопки действий** — открытие ссылок и HTTP-действия из уведомлений.
+- **Фильтры** — правила фильтрации для каждой подписки.
+
+### Конфиденциальность и безопасность
+- **Блокировка приложения** — опциональный PIN/биометрия при запуске (через системный keyring).
+- **Self-hosted** — подключение к частным экземплярам ntfy по HTTPS.
+- **Песочница Flatpak** — строгие разрешения; телеметрии нет.
+- **Только локальные данные** — настройки и история остаются на вашем компьютере.
+
+### Интерфейс
+- **Системный трей** — быстрый доступ и индикация непрочитанного (символическая иконка на тёмных панелях).
+- **Горячие клавиши** — `Ctrl+N` новая тема, `Ctrl+F` поиск, `Ctrl+,` настройки, `F1` справка.
+- **Настройки** — формат даты/времени, автозапуск, запуск в фоне, состояние окна.
+- **Тёмная тема** — следует системной теме.
+
+### Переводы
+
+Интерфейс доступен на английском, русском, немецком, испанском, французском и португальском (в приложении — европейский и бразильский варианты). Новые языки добавляются через gettext — см. [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Сборка из исходников
+
+Нужны Flatpak, `flatpak-builder` и SDK/runtime GNOME 50 (скрипт сборки подтянет их с Flathub).
+
+```bash
+git clone https://github.com/tobagin/Ntfyr.git
+cd Ntfyr
+
+# Production (io.github.tobagin.Ntfyr)
+./build.sh
+
+# Development (io.github.tobagin.Ntfyr.Devel, debug, pre-commit hook)
+./build.sh --dev
+```
+
+Сборка устанавливается в пользовательский Flatpak-репозиторий `~/repo`. Запуск:
+
+```bash
+flatpak run io.github.tobagin.Ntfyr          # production
+flatpak run io.github.tobagin.Ntfyr.Devel    # development
+```
+
+Быстрая итерация без Flatpak (нужны пакеты `gtk4-devel`, `libadwaita-devel`):
+
+```bash
+cargo check   # проверка типов
+cargo clippy  # линтер
+cargo run     # запуск из исходников
+```
+
+Архитектура — в [CLAUDE.md](CLAUDE.md), процесс разработки — в [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Использование
+
+Запустите Ntfyr из меню приложений или выполните:
+
+```bash
+flatpak run io.github.tobagin.Ntfyr
+```
+
+1. Нажмите **+**, чтобы добавить подписку.
+2. Введите имя темы (например, `alerts`).
+3. При необходимости выберите свой сервер или добавьте его в настройках.
+
+Тестовое уведомление:
+
+```bash
+curl -d "Hello from CLI" ntfy.sh/mytopic
+```
+
+### Горячие клавиши
+
+| Сочетание | Действие |
+|-----------|----------|
+| `Ctrl+N` | Подписаться на новую тему |
+| `Ctrl+F` | Поиск по уведомлениям |
+| `Ctrl+,` | Настройки |
+| `Ctrl+Q` | Выход |
+| `F1` | Справка по клавишам |
+
+## Участие в разработке
+
+Вклад приветствуется! Перед pull request прочитайте [CONTRIBUTING.md](CONTRIBUTING.md).
+
+- **Ошибки:** [GitHub Issues](https://github.com/tobagin/Ntfyr/issues)
+- **Вопросы и идеи:** [GitHub Discussions](https://github.com/tobagin/Ntfyr/discussions)
+
+## Лицензия
+
+Ntfyr распространяется под [GPL-3.0-or-later](LICENSE).
+
+## Благодарности
+
+- [ntfy.sh](https://ntfy.sh/) — платформа уведомлений.
+- [GNOME](https://www.gnome.org/) — GTK4 и Libadwaita.
+- [Rust](https://www.rust-lang.org/) — реализация приложения и демона.
+
+## Скриншоты
+
+| Главное окно | Темы | Настройки |
+|--------------|------|-----------|
+| ![Main window](data/screenshots/main-window.png) | ![Topics](data/screenshots/topics.png) | ![Preferences](data/screenshots/preferences.png) |


### PR DESCRIPTION
## Summary
- Refresh the main README for v0.6.1 (features, build instructions, release highlights)
- Add localized README pages: Russian, German, Spanish, French, and Portuguese
- Add a language switcher at the top of each README page

## Test plan
- [x] All six README files render correctly on GitHub
- [x] Language links point to the correct files
- [x] Code blocks, URLs, and screenshot paths unchanged


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive README documentation in German, Spanish, French, Portuguese, and Russian
  * Updated main README with v0.6.1 release highlights, reorganized feature categories, and streamlined usage instructions
  * All language versions include installation guides, keyboard shortcuts, and contribution information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->